### PR TITLE
Update manager dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "valence-account-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "valence-astroport-lper"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4848,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "valence-astroport-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4858,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "valence-astroport-withdrawer"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "valence-authorization"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema 2.2.1",
@@ -4895,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "valence-authorization-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "valence-base-account"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "valence-drop-liquid-staker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4943,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "valence-drop-liquid-unstaker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4963,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "valence-encoder-broker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4977,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "valence-encoder-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "alloy-sol-types",
  "cosmwasm-schema 2.2.1",
@@ -4988,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "valence-forwarder-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "valence-generic-ibc-transfer-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5027,7 +5027,7 @@ dependencies = [
 [[package]]
 name = "valence-gmp-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5036,7 +5036,7 @@ dependencies = [
 [[package]]
 name = "valence-ibc-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema 2.2.1",
@@ -5050,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "valence-library-base"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "valence-library-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5085,7 +5085,7 @@ dependencies = [
 [[package]]
 name = "valence-liquid-staking-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5094,7 +5094,7 @@ dependencies = [
 [[package]]
 name = "valence-macros"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5106,7 +5106,7 @@ dependencies = [
 [[package]]
 name = "valence-middleware-broker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "valence-middleware-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "valence-neutron-ibc-transfer-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5161,7 +5161,7 @@ dependencies = [
 [[package]]
 name = "valence-neutron-ic-querier"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5181,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-cl-lper"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-cl-withdrawer"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5225,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-gamm-lper"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5241,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-gamm-withdrawer"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5257,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5269,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "valence-processor"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "valence-processor-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5301,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "valence-program-manager"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5360,7 +5360,7 @@ dependencies = [
 [[package]]
 name = "valence-program-registry"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5376,11 +5376,10 @@ dependencies = [
 [[package]]
 name = "valence-program-registry-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
- "cw-ownable",
  "serde",
  "serde_json",
 ]
@@ -5388,7 +5387,7 @@ dependencies = [
 [[package]]
 name = "valence-reverse-splitter-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5407,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "valence-splitter-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5427,7 +5426,7 @@ dependencies = [
 [[package]]
 name = "valence-storage-account"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#fee205b7bc99f74c440c119b717ecde944efb648"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",


### PR DESCRIPTION
The manager previously would not allow permissionless writes to the registry. Updating the dependency in the template so deployment uses the most recent deployment logic.