### PR TITLE
fix: use tagged version for template and fix labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -54,97 +54,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "alloy-primitives"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 0.99.19",
- "hex-literal",
- "itoa",
- "k256",
- "keccak-asm",
- "proptest",
- "rand 0.8.5",
- "ruint",
- "serde",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "alloy-rlp"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
-dependencies = [
- "arrayvec",
- "bytes",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck 0.5.0",
- "indexmap 2.8.0",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "syn-solidity",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
-dependencies = [
- "const-hex",
- "dunce",
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-macro",
- "const-hex",
- "serde",
-]
 
 [[package]]
 name = "android-tzdata"
@@ -224,9 +133,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
  "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -235,10 +144,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
@@ -249,32 +158,14 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -282,18 +173,8 @@ dependencies = [
  "num-traits",
  "paste",
  "rayon",
- "rustc_version 0.4.1",
+ "rustc_version",
  "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -302,18 +183,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint",
- "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -337,21 +206,11 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-std 0.3.0",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -361,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.4.0",
+ "ark-std",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -375,16 +234,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -403,12 +252,6 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-stream"
@@ -437,17 +280,6 @@ name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,21 +419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,18 +447,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
 ]
 
 [[package]]
@@ -688,12 +493,6 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -827,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
  "async-trait",
- "convert_case 0.6.0",
+ "convert_case",
  "json5",
  "nom",
  "pathdiff",
@@ -846,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
  "async-trait",
- "convert_case 0.6.0",
+ "convert_case",
  "json5",
  "pathdiff",
  "ron",
@@ -856,19 +655,6 @@ dependencies = [
  "toml",
  "winnow",
  "yaml-rust2 0.10.0",
-]
-
-[[package]]
-name = "const-hex"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "hex",
- "proptest",
- "serde",
 ]
 
 [[package]]
@@ -892,36 +678,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "tiny-keccak 2.0.2",
 ]
-
-[[package]]
-name = "const_format"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -1034,8 +794,8 @@ checksum = "aa2f53285517db3e33d825b3e46301efe845135778527e1295154413b2f0469e"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
+ "ark-ff",
+ "ark-serialize",
  "cosmwasm-core",
  "curve25519-dalek 4.1.3",
  "digest 0.10.7",
@@ -1152,7 +912,7 @@ dependencies = [
  "cosmwasm-core",
  "cosmwasm-crypto 2.2.2",
  "cosmwasm-derive 2.2.2",
- "derive_more 1.0.0",
+ "derive_more",
  "hex",
  "rand_core 0.6.4",
  "rmp-serde",
@@ -1250,7 +1010,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version 0.4.1",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -1309,8 +1069,8 @@ dependencies = [
  "cosmwasm-std 2.2.2",
  "cw-address-like",
  "cw-ownable-derive",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "thiserror 1.0.69",
 ]
 
@@ -1327,17 +1087,6 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
-dependencies = [
- "cosmwasm-std 1.5.11",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw-storage-plus"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f13360e9007f51998d42b1bc6b7fa0141f74feae61ed5fd1e5b0a89eec7b5de1"
@@ -1345,21 +1094,6 @@ dependencies = [
  "cosmwasm-std 2.2.2",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "cw-utils"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a84c6c1c0acc3616398eba50783934bd6c964bad6974241eaee3460c8f5b26"
-dependencies = [
- "cosmwasm-schema 1.5.11",
- "cosmwasm-std 1.5.11",
- "cw2 0.16.0",
- "schemars",
- "semver 1.0.26",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1377,28 +1111,15 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
-dependencies = [
- "cosmwasm-schema 1.5.11",
- "cosmwasm-std 1.5.11",
- "cw-storage-plus 0.16.0",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b04852cd38f044c0751259d5f78255d07590d136b8a86d4e09efdd7666bd6d27"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
+ "cw-storage-plus",
  "schemars",
- "semver 1.0.26",
+ "semver",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -1411,51 +1132,8 @@ checksum = "a42212b6bf29bbdda693743697c621894723f35d3db0d5df930be22903d0e27c"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
- "cw-utils 2.0.0",
+ "cw-utils",
  "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw721"
-version = "0.16.0"
-source = "git+https://github.com/CosmWasm/cw-nfts?tag=v0.16.0#2cad1d3e15e0a34d466a0b51e02c58b82ebe5ecd"
-dependencies = [
- "cosmwasm-schema 1.5.11",
- "cosmwasm-std 1.5.11",
- "cw-utils 0.16.0",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw721"
-version = "0.20.0"
-source = "git+https://github.com/public-awesome/cw-nfts?rev=99dbf7e#99dbf7ee89fd1e13f72380e92ff95a456183b35d"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
- "cw2 2.0.0",
- "cw721 0.16.0",
- "schemars",
- "serde",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "cw721-base"
-version = "0.20.0"
-source = "git+https://github.com/public-awesome/cw-nfts?rev=99dbf7e#99dbf7ee89fd1e13f72380e92ff95a456183b35d"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw2 2.0.0",
- "cw721 0.20.0",
  "serde",
 ]
 
@@ -1522,19 +1200,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -1592,17 +1257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "dlv-list"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,12 +1270,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1784,23 +1432,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "ethbloom"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
 dependencies = [
  "crunchy",
- "fixed-hash 0.3.2",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak 1.5.0",
@@ -1815,9 +1453,9 @@ dependencies = [
  "crunchy",
  "ethbloom",
  "ethereum-types-serialize",
- "fixed-hash 0.3.2",
+ "fixed-hash",
  "serde",
- "uint 0.5.0",
+ "uint",
 ]
 
 [[package]]
@@ -1851,34 +1489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fastrlp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
-name = "fastrlp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,18 +1518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions 1.1.0",
-]
-
-[[package]]
 name = "flex-error"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,15 +1539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "forward_ref"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,12 +1549,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2075,19 +1658,7 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -2239,12 +1810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,160 +1918,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
 name = "impl-rlp"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
 dependencies = [
- "rlp 0.4.6",
+ "rlp",
 ]
 
 [[package]]
@@ -2516,17 +1933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -2699,16 +2105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
-dependencies = [
- "digest 0.10.7",
- "sha3-asm",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,24 +2115,6 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
-
-[[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
-
-[[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2800,7 +2178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -2945,7 +2323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3034,34 +2411,6 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
-dependencies = [
- "arrayvec",
- "bitvec",
- "byte-slice-cast",
- "const_format",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "rustversion",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -3242,50 +2591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash 0.8.0",
- "impl-codec",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,7 +2628,7 @@ dependencies = [
  "clap",
  "cosmwasm-std 2.2.2",
  "cw-denom",
- "cw-utils 2.0.0",
+ "cw-utils",
  "deployer-lib",
  "serde_json",
  "tokio",
@@ -3334,8 +2639,6 @@ dependencies = [
  "valence-authorization",
  "valence-authorization-utils",
  "valence-base-account",
- "valence-drop-liquid-staker",
- "valence-encoder-broker",
  "valence-forwarder-library",
  "valence-generic-ibc-transfer-library",
  "valence-ibc-utils",
@@ -3343,7 +2646,6 @@ dependencies = [
  "valence-library-utils",
  "valence-macros",
  "valence-neutron-ibc-transfer-library",
- "valence-neutron-ic-querier",
  "valence-osmosis-cl-lper",
  "valence-osmosis-cl-withdrawer",
  "valence-osmosis-gamm-lper",
@@ -3355,27 +2657,6 @@ dependencies = [
  "valence-program-registry",
  "valence-reverse-splitter-library",
  "valence-splitter-library",
- "valence-storage-account",
-]
-
-[[package]]
-name = "proptest"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags 2.9.0",
- "lazy_static",
- "num-traits",
- "rand 0.8.5",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
 ]
 
 [[package]]
@@ -3523,12 +2804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,18 +2811,6 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3610,16 +2873,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -3709,16 +2963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,38 +2995,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "ruint"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825df406ec217a8116bd7b06897c6cc8f65ffefc15d030ae2c9540acc9ed50b6"
-dependencies = [
- "alloy-rlp",
- "ark-ff 0.3.0",
- "ark-ff 0.4.2",
- "bytes",
- "fastrlp 0.3.1",
- "fastrlp 0.4.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "parity-scale-codec",
- "primitive-types",
- "proptest",
- "rand 0.8.5",
- "rlp 0.5.2",
- "ruint-macro",
- "serde",
- "valuable",
- "zeroize",
-]
-
-[[package]]
-name = "ruint-macro"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-ini"
@@ -3825,33 +3037,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.26",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "semver",
 ]
 
 [[package]]
@@ -3859,18 +3049,6 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -3942,27 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -4108,16 +3268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
-dependencies = [
- "cc",
- "cfg-if",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4195,12 +3345,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -4308,52 +3452,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-solidity"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
-dependencies = [
- "fastrand",
- "getrandom 0.3.2",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "tendermint"
@@ -4533,16 +3635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -4810,24 +3902,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions 1.1.0",
-]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4855,29 +3929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4885,24 +3936,23 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valence-account-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-utils 2.0.0",
+ "cw-utils",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "valence-ibc-utils",
  "valence-macros",
 ]
 
 [[package]]
 name = "valence-astroport-lper"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -4915,8 +3965,8 @@ dependencies = [
 
 [[package]]
 name = "valence-astroport-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -4925,8 +3975,8 @@ dependencies = [
 
 [[package]]
 name = "valence-astroport-withdrawer"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -4940,50 +3990,48 @@ dependencies = [
 
 [[package]]
 name = "valence-authorization"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
- "cw2 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
  "neutron-sdk",
  "serde_json",
  "thiserror 1.0.69",
  "valence-authorization-utils",
- "valence-encoder-broker",
- "valence-encoder-utils",
- "valence-gmp-utils",
+ "valence-polytone-utils",
  "valence-processor-utils",
 ]
 
 [[package]]
 name = "valence-authorization-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-utils 2.0.0",
+ "cw-utils",
  "serde_json",
- "valence-gmp-utils",
  "valence-library-utils",
+ "valence-polytone-utils",
 ]
 
 [[package]]
 name = "valence-base-account"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
+ "cw-storage-plus",
+ "cw2",
  "schemars",
  "serde",
  "thiserror 1.0.69",
@@ -4991,78 +4039,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "valence-drop-liquid-staker"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw-storage-plus 2.0.0",
- "schemars",
- "serde",
- "thiserror 1.0.69",
- "valence-library-base",
- "valence-library-utils",
- "valence-liquid-staking-utils",
- "valence-macros",
-]
-
-[[package]]
-name = "valence-drop-liquid-unstaker"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw721 0.20.0",
- "cw721-base",
- "schemars",
- "serde",
- "thiserror 1.0.69",
- "valence-library-base",
- "valence-library-utils",
- "valence-liquid-staking-utils",
- "valence-macros",
-]
-
-[[package]]
-name = "valence-encoder-broker"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
- "thiserror 1.0.69",
- "valence-encoder-utils",
-]
-
-[[package]]
-name = "valence-encoder-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "alloy-sol-types",
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "valence-authorization-utils",
-]
-
-[[package]]
 name = "valence-forwarder-library"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "getset",
  "schemars",
  "serde",
@@ -5074,14 +4059,14 @@ dependencies = [
 
 [[package]]
 name = "valence-generic-ibc-transfer-library"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "getset",
  "schemars",
  "serde",
@@ -5093,38 +4078,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "valence-gmp-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
-]
-
-[[package]]
 name = "valence-ibc-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-denom",
- "cw-storage-plus 2.0.0",
+ "cw-storage-plus",
  "neutron-sdk",
  "serde",
 ]
 
 [[package]]
 name = "valence-library-base"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
+ "cw-storage-plus",
+ "cw2",
  "schemars",
  "serde",
  "thiserror 1.0.69",
@@ -5134,36 +4110,26 @@ dependencies = [
 
 [[package]]
 name = "valence-library-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-denom",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "valence-account-utils",
- "valence-ibc-utils",
  "valence-macros",
 ]
 
 [[package]]
-name = "valence-liquid-staking-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
-]
-
-[[package]]
 name = "valence-macros"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -5173,48 +4139,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "valence-middleware-broker"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
- "neutron-sdk",
- "prost 0.13.5",
- "prost-types 0.13.5",
- "semver 1.0.26",
- "serde-json-wasm 1.0.1",
- "serde_json",
- "thiserror 1.0.69",
- "valence-middleware-utils",
-]
-
-[[package]]
-name = "valence-middleware-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "neutron-sdk",
- "prost 0.13.5",
- "semver 1.0.26",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "valence-neutron-ibc-transfer-library"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "getset",
  "neutron-sdk",
  "schemars",
@@ -5228,35 +4161,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "valence-neutron-ic-querier"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
- "neutron-sdk",
- "serde-json-wasm 1.0.1",
- "valence-library-base",
- "valence-library-utils",
- "valence-macros",
- "valence-middleware-broker",
- "valence-middleware-utils",
- "valence-storage-account",
-]
-
-[[package]]
 name = "valence-osmosis-cl-lper"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "osmosis-std",
  "osmosis-std-derive",
  "schemars",
@@ -5271,14 +4184,14 @@ dependencies = [
 
 [[package]]
 name = "valence-osmosis-cl-withdrawer"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "osmosis-std",
  "osmosis-std-derive",
  "schemars",
@@ -5293,8 +4206,8 @@ dependencies = [
 
 [[package]]
 name = "valence-osmosis-gamm-lper"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -5309,8 +4222,8 @@ dependencies = [
 
 [[package]]
 name = "valence-osmosis-gamm-withdrawer"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -5325,8 +4238,8 @@ dependencies = [
 
 [[package]]
 name = "valence-osmosis-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -5336,41 +4249,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "valence-processor"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+name = "valence-polytone-utils"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
- "cw2 2.0.0",
+]
+
+[[package]]
+name = "valence-processor"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
+dependencies = [
+ "cosmwasm-schema 2.2.2",
+ "cosmwasm-std 2.2.2",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
  "serde_json",
  "thiserror 1.0.69",
  "valence-authorization-utils",
- "valence-gmp-utils",
+ "valence-polytone-utils",
  "valence-processor-utils",
 ]
 
 [[package]]
 name = "valence-processor-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "serde",
  "serde_json",
  "valence-authorization-utils",
- "valence-gmp-utils",
+ "valence-polytone-utils",
 ]
 
 [[package]]
 name = "valence-program-manager"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5406,8 +4328,6 @@ dependencies = [
  "valence-astroport-withdrawer",
  "valence-authorization",
  "valence-authorization-utils",
- "valence-drop-liquid-staker",
- "valence-drop-liquid-unstaker",
  "valence-forwarder-library",
  "valence-generic-ibc-transfer-library",
  "valence-library-base",
@@ -5428,14 +4348,14 @@ dependencies = [
 
 [[package]]
 name = "valence-program-registry"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
+ "cw-storage-plus",
+ "cw2",
  "schemars",
  "serde",
  "thiserror 1.0.69",
@@ -5444,8 +4364,8 @@ dependencies = [
 
 [[package]]
 name = "valence-program-registry-utils"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -5455,14 +4375,14 @@ dependencies = [
 
 [[package]]
 name = "valence-reverse-splitter-library"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "getset",
  "schemars",
  "serde",
@@ -5474,14 +4394,14 @@ dependencies = [
 
 [[package]]
 name = "valence-splitter-library"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
+version = "0.1.0"
+source = "git+https://github.com/timewave-computer/valence-protocol?tag=v0.1.2#16e604bcdeb54d9b458809487166b8e9c3371299"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw-utils 2.0.0",
+ "cw-storage-plus",
+ "cw-utils",
  "getset",
  "itertools 0.13.0",
  "schemars",
@@ -5490,23 +4410,6 @@ dependencies = [
  "valence-library-base",
  "valence-library-utils",
  "valence-macros",
-]
-
-[[package]]
-name = "valence-storage-account"
-version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol#33dbcc760b1cd1a5a6388d0cb280696764a8325c"
-dependencies = [
- "cosmwasm-schema 2.2.2",
- "cosmwasm-std 2.2.2",
- "cw-ownable",
- "cw-storage-plus 2.0.0",
- "cw2 2.0.0",
- "schemars",
- "serde",
- "thiserror 1.0.69",
- "valence-account-utils",
- "valence-middleware-utils",
 ]
 
 [[package]]
@@ -5522,15 +4425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5544,15 +4438,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5750,36 +4635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "yaml-rust2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5799,30 +4654,6 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.10.0",
-]
-
-[[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "synstructure",
 ]
 
 [[package]]
@@ -5866,27 +4697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5900,28 +4710,6 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ incremental      = false
 overflow-checks  = true
 
 [workspace.dependencies]
-valence-program-manager = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-program-manager" }
+valence-program-manager = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-program-manager", tag = "v0.1.2" }
 deployer-lib            = { path = "lib" }
 serde_json              = "1.0.125"
 clap                    = { version = "4.5.13", features = ["derive"] }
@@ -44,33 +44,29 @@ cw-utils     = "2.0.0"
 cw-denom     = { package = "cw-denom", git = "https://github.com/DA0-DA0/dao-contracts", branch = "cw-std-2" }
 
 # Libraries
-valence-authorization                = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-authorization", features = ["library"] }
-valence-base-account                 = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-base-account", features = ["library"] }
-valence-storage-account              = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-storage-account", features = ["library"] }
-valence-processor                    = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-processor", features = ["library"] }
-valence-splitter-library             = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-splitter-library", features = ["library"] }
-valence-astroport-lper               = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-astroport-lper", features = ["library"] }
-valence-forwarder-library            = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-forwarder-library", features = ["library"] }
-valence-astroport-withdrawer         = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-astroport-withdrawer", features = ["library"] }
-valence-generic-ibc-transfer-library = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-generic-ibc-transfer-library", features = ["library"] }
-valence-neutron-ibc-transfer-library = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-neutron-ibc-transfer-library", features = ["library"] }
-valence-reverse-splitter-library     = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-reverse-splitter-library", features = ["library"] }
-valence-osmosis-gamm-lper            = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-gamm-lper", features = ["library"] }
-valence-osmosis-gamm-withdrawer      = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-gamm-withdrawer", features = ["library"] }
-valence-osmosis-cl-lper              = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-cl-lper", features = ["library"] }
-valence-osmosis-cl-withdrawer        = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-cl-withdrawer", features = ["library"] }
-valence-encoder-broker               = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-encoder-broker", features = ["library"] }
-valence-neutron-ic-querier           = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-neutron-ic-querier", features = ["library"] }
-valence-drop-liquid-staker           = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-drop-liquid-staker", features = ["library"] }
-valence-program-registry             = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-program-registry", features = ["library"] }
+valence-authorization                = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-authorization", features = ["library"], tag = "v0.1.2" }
+valence-base-account                 = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-base-account", features = ["library"], tag = "v0.1.2" }
+valence-processor                    = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-processor", features = ["library"], tag = "v0.1.2" }
+valence-splitter-library             = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-splitter-library", features = ["library"], tag = "v0.1.2" }
+valence-astroport-lper               = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-astroport-lper", features = ["library"], tag = "v0.1.2" }
+valence-forwarder-library            = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-forwarder-library", features = ["library"], tag = "v0.1.2" }
+valence-astroport-withdrawer         = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-astroport-withdrawer", features = ["library"], tag = "v0.1.2" }
+valence-generic-ibc-transfer-library = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-generic-ibc-transfer-library", features = ["library"], tag = "v0.1.2" }
+valence-neutron-ibc-transfer-library = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-neutron-ibc-transfer-library", features = ["library"], tag = "v0.1.2" }
+valence-reverse-splitter-library     = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-reverse-splitter-library", features = ["library"], tag = "v0.1.2" }
+valence-osmosis-gamm-lper            = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-gamm-lper", features = ["library"], tag = "v0.1.2" }
+valence-osmosis-gamm-withdrawer      = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-gamm-withdrawer", features = ["library"], tag = "v0.1.2" }
+valence-osmosis-cl-lper              = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-cl-lper", features = ["library"], tag = "v0.1.2" }
+valence-osmosis-cl-withdrawer        = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-cl-withdrawer", features = ["library"], tag = "v0.1.2" }
+valence-program-registry             = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-program-registry", features = ["library"], tag = "v0.1.2" }
 
 # utils
-valence-account-utils       = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-account-utils" }
-valence-astroport-utils     = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-astroport-utils" }
-valence-osmosis-utils       = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-utils" }
-valence-authorization-utils = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-authorization-utils" }
-valence-ibc-utils           = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-ibc-utils" }
-valence-macros              = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-macros" }
-valence-processor-utils     = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-processor-utils" }
-valence-library-base        = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-library-base" }
-valence-library-utils       = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-library-utils" }
+valence-account-utils       = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-account-utils", tag = "v0.1.2" }
+valence-astroport-utils     = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-astroport-utils", tag = "v0.1.2" }
+valence-osmosis-utils       = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-osmosis-utils", tag = "v0.1.2" }
+valence-authorization-utils = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-authorization-utils", tag = "v0.1.2" }
+valence-ibc-utils           = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-ibc-utils", tag = "v0.1.2" }
+valence-macros              = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-macros", tag = "v0.1.2" }
+valence-processor-utils     = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-processor-utils", tag = "v0.1.2" }
+valence-library-base        = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-library-base", tag = "v0.1.2" }
+valence-library-utils       = { git = "https://github.com/timewave-computer/valence-protocol", package = "valence-library-utils", tag = "v0.1.2" }

--- a/programs/program_template/Cargo.toml
+++ b/programs/program_template/Cargo.toml
@@ -21,7 +21,6 @@ cw-denom     = { workspace = true }
 # Libraries
 valence-authorization                = { workspace = true }
 valence-base-account                 = { workspace = true }
-valence-storage-account              = { workspace = true }
 valence-processor                    = { workspace = true }
 valence-splitter-library             = { workspace = true }
 valence-astroport-lper               = { workspace = true }
@@ -34,9 +33,6 @@ valence-osmosis-gamm-lper            = { workspace = true }
 valence-osmosis-gamm-withdrawer      = { workspace = true }
 valence-osmosis-cl-lper              = { workspace = true }
 valence-osmosis-cl-withdrawer        = { workspace = true }
-valence-encoder-broker               = { workspace = true }
-valence-neutron-ic-querier           = { workspace = true }
-valence-drop-liquid-staker           = { workspace = true }
 valence-program-registry             = { workspace = true }
 
 # utils

--- a/programs/program_template/src/program_builder.rs
+++ b/programs/program_template/src/program_builder.rs
@@ -109,7 +109,7 @@ pub fn program_builder(params: deployer_lib::ProgramParams) -> ProgramConfig {
         .with_function(function)
         .build();
     let authorization = AuthorizationBuilder::new()
-        .with_label("Forward from first to second")
+        .with_label("Forward_from_first_to_second")
         .with_subroutine(subroutine)
         .build();
 
@@ -134,7 +134,7 @@ pub fn program_builder(params: deployer_lib::ProgramParams) -> ProgramConfig {
         .with_function(function)
         .build();
     let authorization = AuthorizationBuilder::new()
-        .with_label("Forward from second to first")
+        .with_label("Forward_from second_to_first")
         .with_subroutine(subroutine)
         .build();
 
@@ -159,7 +159,7 @@ pub fn program_builder(params: deployer_lib::ProgramParams) -> ProgramConfig {
         .with_function(update_first_forward_config_function)
         .build();
     let authorization = AuthorizationBuilder::new()
-        .with_label("Secure update first forwarder config")
+        .with_label("Secure_update_first_forwarder_config")
         .with_mode(
             valence_authorization_utils::authorization::AuthorizationModeInfo::Permissioned(
                 valence_authorization_utils::authorization::PermissionTypeInfo::WithoutCallLimit(
@@ -191,7 +191,7 @@ pub fn program_builder(params: deployer_lib::ProgramParams) -> ProgramConfig {
         .with_function(update_second_forward_config_function)
         .build();
     let authorization = AuthorizationBuilder::new()
-        .with_label("Secure uodate second forwarder config")
+        .with_label("Secure_update_second_forwarder_config")
         .with_mode(
             valence_authorization_utils::authorization::AuthorizationModeInfo::Permissioned(
                 valence_authorization_utils::authorization::PermissionTypeInfo::WithoutCallLimit(


### PR DESCRIPTION
Uses the latest tagged release for our template instead of the main branch.

Additionally fixes the program which was broken because the labels had spaces which is not allowed for the tokenfactory denoms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Standardized dependency versions across the project.
	- Removed outdated libraries from the project template to streamline dependency management.
- **Style**
	- Refined authorization label formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->